### PR TITLE
Fix participant prioritization

### DIFF
--- a/DailyKit/CallManager/Models/CallParticipantsBuilder.swift
+++ b/DailyKit/CallManager/Models/CallParticipantsBuilder.swift
@@ -45,8 +45,10 @@ extension CallParticipants {
                 // Do not track the local participant because they are not shown in the grid.
                 if let activeSpeaker, activeSpeaker.isLocal == false {
                     speakerOrder.removeAll(where: { $0 == activeSpeaker.id })
+
+                    // We do not use the limit for speaker order to preserve the order of participants that
+                    // could become visible again after higher priority participants leave.
                     speakerOrder.append(activeSpeaker.id)
-                    speakerOrder = Array(speakerOrder.prefix(limit))
                 }
             }
         }
@@ -80,8 +82,7 @@ extension CallParticipants {
                 var withoutVideo: [CallParticipant] = []
 
                 let participants = participantIDs
-                    .map { remote[$0] }
-                    .compactMap { $0 }
+                    .compactMap { remote[$0] }
 
                 for participant in participants {
                     if participant.hasVideo {
@@ -116,8 +117,9 @@ extension CallParticipants {
         mutating func handleJoined(_ participant: CallParticipant) {
             assert(participant.isLocal == false, "Unexpected join event for the local participant.")
 
+            // We do not use the limit for join order to preserve the order of participants that could become
+            // visible again after higher priority participants leave.
             joinOrder.append(participant.id)
-            joinOrder = Array(joinOrder.prefix(limit))
 
             remote[participant.id] = participant
         }

--- a/DailyKitTests/CallParticipantsTests.swift
+++ b/DailyKitTests/CallParticipantsTests.swift
@@ -1,8 +1,12 @@
 @testable import DailyKit
 import XCTest
 
-final class CallParticipantsTests: XCTestCase, TestSupport {
-    func testStabilizePreservesOrderWhenEqual() throws {
+final class CallParticipantsTests: XCTestCase, TestSupport {}
+
+// MARK: - Ordering
+
+extension CallParticipantsTests {
+    func testStabilizePreservesOrderWhenOrderDoesNotChange() throws {
         let visible = [
             CallParticipant(username: "0"),
             CallParticipant(username: "1"),
@@ -104,12 +108,12 @@ final class CallParticipantsTests: XCTestCase, TestSupport {
 
         let participants = previous.stabilize(current)
 
-        XCTAssertEqual(participants.visible.mapValues(\.username), [
-            0: visible[0].username,
-            1: visible[1].username,
-            2: visible[2].username,
-            3: visible[3].username,
-            4: visible[4].username,
+        assertParticipants(participants, visibleEquals: [
+            visible[0],
+            visible[1],
+            visible[2],
+            visible[3],
+            visible[4],
         ])
     }
 
@@ -140,6 +144,121 @@ final class CallParticipantsTests: XCTestCase, TestSupport {
             visible[3],
             visible[1],
             visible[2],
+        ])
+    }
+}
+
+// MARK: - New Values
+
+extension CallParticipantsTests {
+    func testStabilizePreservesNewValuesWhenOrderDoesNotChange() throws {
+        let previous = makeCallParticipants(visible: [
+            CallParticipant(id: 0, username: "0", hasVideo: false),
+            CallParticipant(id: 1, username: "1", hasVideo: false),
+            CallParticipant(id: 2, username: "2", hasVideo: false),
+        ])
+        let current = makeCallParticipants(visible: [
+            CallParticipant(id: 0, username: "0", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+        ])
+
+        let participants = previous.stabilize(current)
+
+        assertParticipants(participants, visibleEquals: [
+            CallParticipant(id: 0, username: "0", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+        ])
+    }
+
+    func testStabilizePreservesNewValuesWhenParticipantsAreMoved() throws {
+        let previous = makeCallParticipants(visible: [
+            CallParticipant(id: 0, username: "0", hasVideo: false),
+            CallParticipant(id: 1, username: "1", hasVideo: false),
+            CallParticipant(id: 2, username: "2", hasVideo: false),
+        ])
+        let current = makeCallParticipants(visible: [
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 0, username: "0", hasVideo: true),
+        ])
+
+        let participants = previous.stabilize(current)
+
+        assertParticipants(participants, visibleEquals: [
+            CallParticipant(id: 0, username: "0", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+        ])
+    }
+
+    func testStabilizePreservesNewValuesWhenAddingAndRemovingParticipants() throws {
+        let previous = makeCallParticipants(visible: [
+            CallParticipant(id: 0, username: "0", hasVideo: false),
+            CallParticipant(id: 1, username: "1", hasVideo: false),
+            CallParticipant(id: 2, username: "2", hasVideo: false),
+        ])
+        let current = makeCallParticipants(visible: [
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+            CallParticipant(id: 3, username: "3", hasVideo: true),
+        ])
+
+        let participants = previous.stabilize(current)
+
+        assertParticipants(participants, visibleEquals: [
+            CallParticipant(id: 3, username: "3", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+        ])
+    }
+
+    func testStabilizePreservesNewValuesWhenOthersIsBigger() throws {
+        let previous = makeCallParticipants(visible: [
+            CallParticipant(id: 0, username: "0", hasVideo: false),
+            CallParticipant(id: 1, username: "1", hasVideo: false),
+            CallParticipant(id: 2, username: "2", hasVideo: false),
+        ])
+        let current = makeCallParticipants(visible: [
+            CallParticipant(id: 3, username: "3", hasVideo: true),
+            CallParticipant(id: 4, username: "4", hasVideo: true),
+            CallParticipant(id: 0, username: "0", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+        ])
+
+        let participants = previous.stabilize(current)
+
+        assertParticipants(participants, visibleEquals: [
+            CallParticipant(id: 0, username: "0", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+            CallParticipant(id: 3, username: "3", hasVideo: true),
+            CallParticipant(id: 4, username: "4", hasVideo: true),
+        ])
+    }
+
+    func testStabilizePreservesNewValuesWhenOthersIsSmaller() throws {
+        let previous = makeCallParticipants(visible: [
+            CallParticipant(id: 0, username: "0", hasVideo: false),
+            CallParticipant(id: 1, username: "1", hasVideo: false),
+            CallParticipant(id: 2, username: "2", hasVideo: false),
+            CallParticipant(id: 3, username: "3", hasVideo: false),
+            CallParticipant(id: 4, username: "4", hasVideo: false),
+        ])
+        let current = makeCallParticipants(visible: [
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
+            CallParticipant(id: 3, username: "3", hasVideo: true),
+        ])
+
+        let participants = previous.stabilize(current)
+
+        assertParticipants(participants, visibleEquals: [
+            CallParticipant(id: 3, username: "3", hasVideo: true),
+            CallParticipant(id: 1, username: "1", hasVideo: true),
+            CallParticipant(id: 2, username: "2", hasVideo: true),
         ])
     }
 }


### PR DESCRIPTION
The active speaker was not being shown once at the visible limit because we were using `prefix` instead of `suffix`. We will now preserve the full recency lists, which is needed to maintain the priority order after participants leave in some cases.