### PR TITLE
Introduce `ContextView`

### DIFF
--- a/DailyKit/CallManager/CallManager.swift
+++ b/DailyKit/CallManager/CallManager.swift
@@ -4,6 +4,9 @@ import Daily
 
 /// The live implementation of `CallManageable`.
 public final class CallManager: CallManageable {
+    /// A singleton instance for use in production code.
+    public static let live: CallManager = .init()
+
     // MARK: - State
 
     public var url: URL? { subjects.url.value }

--- a/DailyStarterKit.xcodeproj/project.pbxproj
+++ b/DailyStarterKit.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4972C1942A0DAD5B00D17DA0 /* DailyStarterKitUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4972C1932A0DAD5B00D17DA0 /* DailyStarterKitUITestsLaunchTests.swift */; };
 		497315342A1EB1940024A578 /* CallControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497315332A1EB1940024A578 /* CallControlsView.swift */; };
 		49771FE52A4FA34F007B24DF /* GridGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49771FE42A4FA34F007B24DF /* GridGeometry.swift */; };
+		49AE16E42A72C7490078D50E /* ContextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AE16E32A72C7490078D50E /* ContextView.swift */; };
 		49B040502A58CD1D00612934 /* CallParticipantsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B0404F2A58CD1D00612934 /* CallParticipantsBuilder.swift */; };
 		49B040522A58DC3D00612934 /* VideoTrack+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B040512A58DC3D00612934 /* VideoTrack+Hashable.swift */; };
 		49B92B4B2A52249300F81BAB /* TestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B92B4A2A52249300F81BAB /* TestSupport.swift */; };
@@ -144,6 +145,7 @@
 		4995FB4A2A465E850070117F /* CallParticipants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipants.swift; sourceTree = "<group>"; };
 		4995FB4C2A4660F30070117F /* CallParticipantsBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallParticipantsBuilderTests.swift; sourceTree = "<group>"; };
 		49A764432A1C06A5003A9668 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		49AE16E32A72C7490078D50E /* ContextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextView.swift; sourceTree = "<group>"; };
 		49B0404F2A58CD1D00612934 /* CallParticipantsBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallParticipantsBuilder.swift; sourceTree = "<group>"; };
 		49B040512A58DC3D00612934 /* VideoTrack+Hashable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VideoTrack+Hashable.swift"; sourceTree = "<group>"; };
 		49B1BD562A210025003033EB /* DailyStarterKitUITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DailyStarterKitUITests.xctestplan; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 			isa = PBXGroup;
 			children = (
 				4940954E2A0DAF02006D9500 /* Colors.swift */,
+				49AE16E32A72C7490078D50E /* ContextView.swift */,
 				49C55AEF2A1BD1B700FF409F /* DailyVideoView.swift */,
 				491AA4CF2A27BE3900EEC919 /* ParticipantView.swift */,
 				4959DCA42A21699800B68712 /* PrimaryButtonStyle.swift */,
@@ -628,6 +631,7 @@
 				4940954F2A0DAF02006D9500 /* Colors.swift in Sources */,
 				49605B132A44D61600A0E3A8 /* ToastManager.swift in Sources */,
 				49605B152A44D61B00A0E3A8 /* Toast.swift in Sources */,
+				49AE16E42A72C7490078D50E /* ContextView.swift in Sources */,
 				4969A9C62A2AD72200071CA8 /* CallControlsOverlayView.swift in Sources */,
 				4969A9C82A2ADCD000071CA8 /* GridLayoutView.swift in Sources */,
 				493FDE862A1C3D2E0089A129 /* InCallView.swift in Sources */,

--- a/DailyStarterKit/Call/CallContainerView.swift
+++ b/DailyStarterKit/Call/CallContainerView.swift
@@ -60,16 +60,9 @@ struct CallContainerView: View {
 #if DEBUG
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        let manager = FakeCallManager()
-
-        CallContainerView()
-            .environmentObject(CallContainerView.Model(manager: manager))
-            .environmentObject(CallControlsOverlayView.Model(manager: manager))
-            .environmentObject(CallControlsView.Model(manager: manager))
-            .environmentObject(CallDetailsView.Model(manager: manager))
-            .environmentObject(InCallView.Model(manager: manager))
-            .environmentObject(JoinLayoutView.Model(manager: manager))
-            .environmentObject(WaitingLayoutView.Model(callManager: manager, toastManager: ToastManager()))
+        ContextView(callManager: FakeCallManager()) {
+            CallContainerView()
+        }
     }
 }
 #endif

--- a/DailyStarterKit/Call/CallControlsOverlayView.swift
+++ b/DailyStarterKit/Call/CallControlsOverlayView.swift
@@ -168,28 +168,26 @@ struct CallControlsOverlayView: View {
 #if DEBUG
 struct CallControlsOverlayView_Previews: PreviewProvider {
     static var previews: some View {
-        let manager = FakeCallManager()
+        ContextView(callManager: FakeCallManager()) {
+            Group {
+                ZStack {
+                    Text("In a call...")
 
-        Group {
-            ZStack {
-                Text("In a call...")
+                    CallControlsOverlayView()
+                }
+                .previewDisplayName("Portrait")
+                .previewInterfaceOrientation(.portrait)
 
-                CallControlsOverlayView()
+                ZStack {
+                    Text("In a call...")
+
+                    CallControlsOverlayView()
+                }
+                .previewDisplayName("Landscape")
+                .previewInterfaceOrientation(.landscapeRight)
+                .callLayout(.landscape)
             }
-            .previewDisplayName("Portrait")
-            .previewInterfaceOrientation(.portrait)
-
-            ZStack {
-                Text("In a call...")
-
-                CallControlsOverlayView()
-            }
-            .previewDisplayName("Landscape")
-            .previewInterfaceOrientation(.landscapeRight)
-            .callLayout(.landscape)
         }
-        .environmentObject(CallControlsOverlayView.Model(manager: manager))
-        .environmentObject(CallControlsView.Model(manager: manager))
     }
 }
 #endif

--- a/DailyStarterKit/Call/CallControlsView.swift
+++ b/DailyStarterKit/Call/CallControlsView.swift
@@ -148,20 +148,19 @@ struct CallControlsView: View {
 #if DEBUG
 struct CallControlsView_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
-            CallControlsView(shouldShowLeaveButton: false)
-                .previewLayout(.sizeThatFits)
-                .previewDisplayName("Camera, Microphone")
+        ContextView(callManager: FakeCallManager()) {
+            Group {
+                CallControlsView(shouldShowLeaveButton: false)
+                    .previewLayout(.sizeThatFits)
+                    .previewDisplayName("Camera, Microphone")
 
-            CallControlsView(shouldShowLeaveButton: true)
-                .previewLayout(.sizeThatFits)
-                .previewDisplayName("Camera, Microphone, Leave")
+                CallControlsView(shouldShowLeaveButton: true)
+                    .previewLayout(.sizeThatFits)
+                    .previewDisplayName("Camera, Microphone, Leave")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Colors.backgroundPrimary)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Colors.backgroundPrimary)
-        .environmentObject(CallControlsView.Model(
-            manager: FakeCallManager()
-        ))
     }
 }
 #endif

--- a/DailyStarterKit/Call/CallDetailsView.swift
+++ b/DailyStarterKit/Call/CallDetailsView.swift
@@ -110,13 +110,12 @@ struct CallDetailsView: View {
 #if DEBUG
 struct CallDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        CallDetailsView(
-            isPresented: .constant(true)
-        )
-        .environmentObject(CallDetailsView.Model(manager: FakeCallManager(
+        ContextView(callManager: FakeCallManager(
             local: .defaultLocal,
             visible: (0 ..< 19).map { CallParticipant(hasAudio: $0.isMultiple(of: 2)) }
-        )))
+        )) {
+            CallDetailsView(isPresented: .constant(true))
+        }
     }
 }
 #endif

--- a/DailyStarterKit/Call/InCallView.swift
+++ b/DailyStarterKit/Call/InCallView.swift
@@ -70,18 +70,9 @@ struct InCallView: View {
 #if DEBUG
 struct InCallView_Previews: PreviewProvider {
     static var previews: some View {
-        let callManager = FakeCallManager()
-        let toastManager = ToastManager()
-
-        InCallView()
-            .environmentObject(CallControlsOverlayView.Model(manager: callManager))
-            .environmentObject(CallControlsView.Model(manager: callManager))
-            .environmentObject(CallDetailsView.Model(manager: callManager))
-            .environmentObject(GridLayoutView.Model(manager: callManager))
-            .environmentObject(InCallView.Model(manager: callManager))
-            .environmentObject(JoinLayoutView.Model(manager: callManager))
-            .environmentObject(WaitingLayoutView.Model(callManager: callManager, toastManager: toastManager))
-            .environmentObject(ToastOverlayView.Model(manager: toastManager))
+        ContextView(callManager: FakeCallManager()) {
+            InCallView()
+        }
     }
 }
 #endif

--- a/DailyStarterKit/Common/ContextView.swift
+++ b/DailyStarterKit/Common/ContextView.swift
@@ -1,0 +1,65 @@
+import DailyKit
+import SwiftUI
+
+struct ContextView<Content: View>: View {
+    @StateObject private var callContainerViewModel: CallContainerView.Model
+    @StateObject private var callControlsOverlayViewModel: CallControlsOverlayView.Model
+    @StateObject private var callControlsViewModel: CallControlsView.Model
+    @StateObject private var callDetailsViewModel: CallDetailsView.Model
+    @StateObject private var gridLayoutViewModel: GridLayoutView.Model
+    @StateObject private var inCallViewModel: InCallView.Model
+    @StateObject private var joinLayoutViewModel: JoinLayoutView.Model
+    @StateObject private var toastOverlayViewModel: ToastOverlayView.Model
+    @StateObject private var waitingLayoutViewModel: WaitingLayoutView.Model
+
+    private let content: () -> Content
+
+    init(
+        callManager: CallManageable,
+        toastManager: ToastManager = .live,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self._callContainerViewModel = StateObject(
+            wrappedValue: CallContainerView.Model(manager: callManager)
+        )
+        self._callControlsOverlayViewModel = StateObject(
+            wrappedValue: CallControlsOverlayView.Model(manager: callManager)
+        )
+        self._callControlsViewModel = StateObject(
+            wrappedValue: CallControlsView.Model(manager: callManager)
+        )
+        self._callDetailsViewModel = StateObject(
+            wrappedValue: CallDetailsView.Model(manager: callManager)
+        )
+        self._gridLayoutViewModel = StateObject(
+            wrappedValue: GridLayoutView.Model(manager: callManager)
+        )
+        self._inCallViewModel = StateObject(
+            wrappedValue: InCallView.Model(manager: callManager)
+        )
+        self._joinLayoutViewModel = StateObject(
+            wrappedValue: JoinLayoutView.Model(manager: callManager)
+        )
+        self._toastOverlayViewModel = StateObject(
+            wrappedValue: ToastOverlayView.Model(manager: toastManager)
+        )
+        self._waitingLayoutViewModel = StateObject(
+            wrappedValue: WaitingLayoutView.Model(callManager: callManager, toastManager: toastManager)
+        )
+
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .environmentObject(callContainerViewModel)
+            .environmentObject(callControlsOverlayViewModel)
+            .environmentObject(callControlsViewModel)
+            .environmentObject(callDetailsViewModel)
+            .environmentObject(gridLayoutViewModel)
+            .environmentObject(inCallViewModel)
+            .environmentObject(joinLayoutViewModel)
+            .environmentObject(toastOverlayViewModel)
+            .environmentObject(waitingLayoutViewModel)
+    }
+}

--- a/DailyStarterKit/DailyStarterKitApp.swift
+++ b/DailyStarterKit/DailyStarterKitApp.swift
@@ -5,18 +5,9 @@ import SwiftUI
 struct DailyStarterKitApp: App {
     var body: some Scene {
         WindowGroup {
-            let callManager = CallManager()
-            let toastManager = ToastManager()
-            CallContainerView()
-                .environmentObject(CallContainerView.Model(manager: callManager))
-                .environmentObject(CallControlsOverlayView.Model(manager: callManager))
-                .environmentObject(CallControlsView.Model(manager: callManager))
-                .environmentObject(CallDetailsView.Model(manager: callManager))
-                .environmentObject(GridLayoutView.Model(manager: callManager))
-                .environmentObject(InCallView.Model(manager: callManager))
-                .environmentObject(JoinLayoutView.Model(manager: callManager))
-                .environmentObject(ToastOverlayView.Model(manager: toastManager))
-                .environmentObject(WaitingLayoutView.Model(callManager: callManager, toastManager: toastManager))
+            ContextView(callManager: CallManager.live) {
+                CallContainerView()
+            }
         }
     }
 }

--- a/DailyStarterKit/Layouts/GridLayoutView.swift
+++ b/DailyStarterKit/Layouts/GridLayoutView.swift
@@ -182,39 +182,43 @@ struct GridLayoutView: View {
 #if DEBUG
 struct GridLayoutView_Previews: PreviewProvider {
     static var previews: some View {
-        let phoneManager = FakeCallManager(visible: (0 ..< 5).map { _ in CallParticipant() })
-        ForEach([
-            "iPhone 14 Pro",
-        ], id: \.self) { deviceName in
-            GridLayoutView()
-                .previewDevice(PreviewDevice(rawValue: deviceName))
-                .previewDisplayName("\(deviceName) Portrait")
-                .previewInterfaceOrientation(.portrait)
+        ContextView(callManager: FakeCallManager(
+            visible: (0 ..< 5).map { _ in CallParticipant() })
+        ) {
+            ForEach([
+                "iPhone 14 Pro",
+            ], id: \.self) { deviceName in
+                GridLayoutView()
+                    .previewDevice(PreviewDevice(rawValue: deviceName))
+                    .previewDisplayName("\(deviceName) Portrait")
+                    .previewInterfaceOrientation(.portrait)
 
-            GridLayoutView()
-                .previewDevice(PreviewDevice(rawValue: deviceName))
-                .previewDisplayName("\(deviceName) Landscape")
-                .previewInterfaceOrientation(.landscapeRight)
-                .callLayout(.landscape)
+                GridLayoutView()
+                    .previewDevice(PreviewDevice(rawValue: deviceName))
+                    .previewDisplayName("\(deviceName) Landscape")
+                    .previewInterfaceOrientation(.landscapeRight)
+                    .callLayout(.landscape)
+            }
         }
-        .environmentObject(GridLayoutView.Model(manager: phoneManager))
 
-        let padManager = FakeCallManager(visible: (0 ..< 11).map { _ in CallParticipant() })
-        ForEach([
-            "iPad mini (6th generation)",
-        ], id: \.self) { deviceName in
-            GridLayoutView()
-                .previewDevice(PreviewDevice(rawValue: deviceName))
-                .previewDisplayName("\(deviceName) Portrait")
-                .previewInterfaceOrientation(.portrait)
+        ContextView(callManager: FakeCallManager(
+            visible: (0 ..< 11).map { _ in CallParticipant() })
+        ) {
+            ForEach([
+                "iPad mini (6th generation)",
+            ], id: \.self) { deviceName in
+                GridLayoutView()
+                    .previewDevice(PreviewDevice(rawValue: deviceName))
+                    .previewDisplayName("\(deviceName) Portrait")
+                    .previewInterfaceOrientation(.portrait)
 
-            GridLayoutView()
-                .previewDevice(PreviewDevice(rawValue: deviceName))
-                .previewDisplayName("\(deviceName) Landscape")
-                .previewInterfaceOrientation(.landscapeRight)
-                .callLayout(.landscape)
+                GridLayoutView()
+                    .previewDevice(PreviewDevice(rawValue: deviceName))
+                    .previewDisplayName("\(deviceName) Landscape")
+                    .previewInterfaceOrientation(.landscapeRight)
+                    .callLayout(.landscape)
+            }
         }
-        .environmentObject(GridLayoutView.Model(manager: padManager))
     }
 }
 #endif

--- a/DailyStarterKit/Layouts/JoinLayoutView.swift
+++ b/DailyStarterKit/Layouts/JoinLayoutView.swift
@@ -237,19 +237,18 @@ struct JoinLayoutView: View {
 #if DEBUG
 struct JoinView_Previews: PreviewProvider {
     static var previews: some View {
-        let manager = FakeCallManager()
-        Group {
-            JoinLayoutView()
-                .previewDisplayName("iPhone Portrait")
-                .previewInterfaceOrientation(.portrait)
+        ContextView(callManager: FakeCallManager()) {
+            Group {
+                JoinLayoutView()
+                    .previewDisplayName("iPhone Portrait")
+                    .previewInterfaceOrientation(.portrait)
 
-            JoinLayoutView()
-                .previewDisplayName("iPhone Landscape")
-                .previewInterfaceOrientation(.landscapeRight)
-                .callLayout(.landscape)
+                JoinLayoutView()
+                    .previewDisplayName("iPhone Landscape")
+                    .previewInterfaceOrientation(.landscapeRight)
+                    .callLayout(.landscape)
+            }
         }
-        .environmentObject(JoinLayoutView.Model(manager: manager))
-        .environmentObject(CallControlsView.Model(manager: manager))
     }
 }
 #endif

--- a/DailyStarterKit/Layouts/WaitingLayoutView.swift
+++ b/DailyStarterKit/Layouts/WaitingLayoutView.swift
@@ -106,29 +106,29 @@ struct WaitingLayoutView: View {
 #if DEBUG
 struct WaitingView_Previews: PreviewProvider {
     static var previews: some View {
-        let manager = FakeCallManager(url: URL(string: "https://example.com")!)
-        Group {
-            WaitingLayoutView()
-                .previewDisplayName("iPhone Portrait")
-                .previewInterfaceOrientation(.portrait)
+        ContextView(callManager: FakeCallManager()) {
+            Group {
+                WaitingLayoutView()
+                    .previewDisplayName("iPhone Portrait")
+                    .previewInterfaceOrientation(.portrait)
 
-            WaitingLayoutView()
-                .previewDisplayName("iPhone Landscape")
-                .previewInterfaceOrientation(.landscapeRight)
-                .callLayout(.landscape)
+                WaitingLayoutView()
+                    .previewDisplayName("iPhone Landscape")
+                    .previewInterfaceOrientation(.landscapeRight)
+                    .callLayout(.landscape)
 
-            WaitingLayoutView()
-                .previewDevice(PreviewDevice(rawValue: "iPad mini (6th generation)"))
-                .previewDisplayName("iPad Portrait")
-                .previewInterfaceOrientation(.portrait)
+                WaitingLayoutView()
+                    .previewDevice(PreviewDevice(rawValue: "iPad mini (6th generation)"))
+                    .previewDisplayName("iPad Portrait")
+                    .previewInterfaceOrientation(.portrait)
 
-            WaitingLayoutView()
-                .previewDevice(PreviewDevice(rawValue: "iPad mini (6th generation)"))
-                .previewDisplayName("iPad Landscape")
-                .previewInterfaceOrientation(.landscapeRight)
-                .callLayout(.landscape)
+                WaitingLayoutView()
+                    .previewDevice(PreviewDevice(rawValue: "iPad mini (6th generation)"))
+                    .previewDisplayName("iPad Landscape")
+                    .previewInterfaceOrientation(.landscapeRight)
+                    .callLayout(.landscape)
+            }
         }
-        .environmentObject(WaitingLayoutView.Model(callManager: manager, toastManager: ToastManager()))
     }
 }
 #endif

--- a/DailyStarterKit/Toasts/ToastManager.swift
+++ b/DailyStarterKit/Toasts/ToastManager.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 /// A manager used to show toasts.
 final class ToastManager: ObservableObject {
+    /// A singleton instance for use in production code.
+    public static let live: ToastManager = .init()
+
     private enum Constants {
         /// The length of time for which to show a toast.
         static let toastVisibilityDuration: Duration = .seconds(3)


### PR DESCRIPTION
Previously we needed to update the `environmentObject` calls in all previews, which was error prone and tedious. Using the `ContextView` allows us to make updates in one place, and it will be easier to refactor the model layer if we want to pass models explicitly instead of using `environmentObject` in the future.