### PR TITLE
Reduce prominence of placeholder text

### DIFF
--- a/DailyStarterKit/Common/Colors.swift
+++ b/DailyStarterKit/Common/Colors.swift
@@ -14,6 +14,8 @@ struct Colors {
 
     static let textPrimaryPrompt = Color.white.opacity(0.4)
 
+    static let textSecondaryPrompt = textPrimaryPrompt.opacity(0.5)
+
     // rgba(27, 235, 185, 1)
     static let accent = Color(red: 27 / 255, green: 235 / 255, blue: 185 / 255)
 }
@@ -27,6 +29,7 @@ struct Colors_Previews: PreviewProvider {
             Colors.borderSecondary
             Colors.textPrimary
             Colors.textPrimaryPrompt
+            Colors.textSecondaryPrompt
             Colors.accent
         }
         .background(.gray)

--- a/DailyStarterKit/Layouts/JoinLayoutView.swift
+++ b/DailyStarterKit/Layouts/JoinLayoutView.swift
@@ -152,7 +152,7 @@ struct JoinLayoutView: View {
                     text: $model.meetingURLString,
                     prompt:
                         Text(verbatim: "https://meeting.daily.co/example...")
-                        .foregroundColor(Colors.textPrimary.opacity(0.9))
+                        .foregroundColor(Colors.textSecondaryPrompt)
                 )
                 .keyboardType(.URL)
                 .submitLabel(.done)
@@ -178,7 +178,7 @@ struct JoinLayoutView: View {
                     text: $model.username,
                     prompt:
                         Text(verbatim: "Jane Smith...")
-                        .foregroundColor(Colors.textPrimary.opacity(0.9))
+                        .foregroundColor(Colors.textSecondaryPrompt)
 
                 )
                 .disableAutocorrection(true)


### PR DESCRIPTION
The previous color was too close to entered text, so we will now use a color that looks closer to grey.