### PR TITLE
Reset participant state between calls

### DIFF
--- a/DailyKit/CallManager/CallManager.swift
+++ b/DailyKit/CallManager/CallManager.swift
@@ -34,9 +34,7 @@ public final class CallManager: CallManageable {
     /// - Parameter callClient: the Daily `CallClient` instance to use for this manager.
     required init(callClient: CallClient) {
         self.callClient = callClient
-        self.participantsBuilder = CallParticipants.Builder(
-            local: callClient.participants.local.asCallParticipant
-        )
+        self.participantsBuilder = CallParticipants.Builder(callClient)
         self.subjects = CallClientSubjects(
             url: callClient.url,
             callState: callClient.callState,
@@ -125,6 +123,9 @@ extension CallManager: CallClientDelegate {
         // Reapply the defaults after leaving a call.
         if case CallState.left = state {
             applyDefaults()
+
+            // Recreate the builder to remove any stale participant state.
+            participantsBuilder = CallParticipants.Builder(callClient)
         }
     }
 

--- a/DailyKit/CallManager/Models/CallParticipantsBuilder.swift
+++ b/DailyKit/CallManager/Models/CallParticipantsBuilder.swift
@@ -154,3 +154,13 @@ extension CallParticipants {
         }
     }
 }
+
+extension CallParticipants.Builder {
+    @MainActor
+    /// Makes a builder for the specified call client.
+    ///
+    /// - Parameter callClient: the call client for which to make a builder.
+    init(_ callClient: CallClient) {
+        self.init(local: callClient.participants.local.asCallParticipant)
+    }
+}


### PR DESCRIPTION
Consecutively joining different calls could result in ghost participants because we would not get participant left events. We will now recreate the `CallParticipants.Builder` after leaving a call.