### PR TITLE
Promote models to top-level types

### DIFF
--- a/DailyStarterKit/Call/CallContainerView.swift
+++ b/DailyStarterKit/Call/CallContainerView.swift
@@ -2,39 +2,39 @@ import Combine
 import DailyKit
 import SwiftUI
 
-struct CallContainerView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class CallContainerModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: CallManageable
-        private var subscriptions: Set<AnyCancellable> = []
+    private let manager: CallManageable
+    private var subscriptions: Set<AnyCancellable> = []
 
-        init(manager: CallManageable) {
-            self.manager = manager
+    init(manager: CallManageable) {
+        self.manager = manager
 
-            manager.publisher(for: .callState)
-                .map { [.joining, .joined].contains($0) }
-                .assign(to: &$isInCall)
+        manager.publisher(for: .callState)
+            .map { [.joining, .joined].contains($0) }
+            .assign(to: &$isInCall)
 
-            $isInCall.sink { isJoined in
-                // Disable the idle timer to keep the screen awake while in a call.
-                UIApplication.shared.isIdleTimerDisabled = isJoined
-            }
-            .store(in: &subscriptions)
+        $isInCall.sink { isJoined in
+            // Disable the idle timer to keep the screen awake while in a call.
+            UIApplication.shared.isIdleTimerDisabled = isJoined
         }
-
-        // MARK: - Properties
-
-        // Whether the call is in the `joining` or `joined` call state.
-        @Published private(set) var isInCall: Bool = false
+        .store(in: &subscriptions)
     }
 
-    // MARK: - View
+    // MARK: - Properties
 
-    @EnvironmentObject private var model: Model
+    // Whether the call is in the `joining` or `joined` call state.
+    @Published private(set) var isInCall: Bool = false
+}
+
+// MARK: - View
+
+struct CallContainerView: View {
+    @EnvironmentObject private var model: CallContainerModel
 
     var body: some View {
         GeometryReader { geometry in

--- a/DailyStarterKit/Call/CallControlsOverlayView.swift
+++ b/DailyStarterKit/Call/CallControlsOverlayView.swift
@@ -3,48 +3,50 @@ import Combine
 import DailyKit
 import SwiftUI
 
-struct CallControlsOverlayView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class CallControlsOverlayModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: CallManageable
-        private var camera: CallCamera
-        private var subscriptions: Set<AnyCancellable> = []
+    private let manager: CallManageable
+    private var camera: CallCamera
+    private var subscriptions: Set<AnyCancellable> = []
 
-        init(manager: CallManageable) {
-            self.manager = manager
-            self.camera = manager.camera
+    init(manager: CallManageable) {
+        self.manager = manager
+        self.camera = manager.camera
 
-            manager.publisher(for: .camera)
-                .sink { [weak self] camera in
-                    guard let self else { return }
+        manager.publisher(for: .camera)
+            .sink { [weak self] camera in
+                guard let self else { return }
 
-                    // We assign the `camera` value directly instead of using `assign(to:)` because the view
-                    // does not need to be updated when the value changes.
-                    self.camera = camera
-                }
-                .store(in: &subscriptions)
-        }
-
-        // MARK: - Properties
-
-        @Published var isCallDetailsViewPresented: Bool = false
-
-        // MARK: - Actions
-
-        func cameraButtonTapped() {
-            manager.flipCamera(camera)
-        }
-
-        func moreButtonTapped() {
-            isCallDetailsViewPresented = true
-        }
+                // We assign the `camera` value directly instead of using `assign(to:)` because the view
+                // does not need to be updated when the value changes.
+                self.camera = camera
+            }
+            .store(in: &subscriptions)
     }
 
-    // MARK: - RoutePickerButton
+    // MARK: - Properties
+
+    @Published var isCallDetailsViewPresented: Bool = false
+
+    // MARK: - Actions
+
+    func cameraButtonTapped() {
+        manager.flipCamera(camera)
+    }
+
+    func moreButtonTapped() {
+        isCallDetailsViewPresented = true
+    }
+}
+
+// MARK: - View
+
+struct CallControlsOverlayView: View {
+    // MARK: -
 
     private struct RoutePickerButton<Content: View>: View {
         /// The custom label to be shown over the route picker button.
@@ -59,7 +61,7 @@ struct CallControlsOverlayView: View {
         }
     }
 
-    // MARK: - RoutePickerView
+    // MARK: -
 
     private struct RoutePickerView: UIViewRepresentable {
         func makeUIView(context: Context) -> UIView {
@@ -73,10 +75,10 @@ struct CallControlsOverlayView: View {
 
         func updateUIView(_ uiView: UIView, context: Context) {}
     }
+    
+    // MARK: -
 
-    // MARK: - View
-
-    @EnvironmentObject private var model: Model
+    @EnvironmentObject private var model: CallControlsOverlayModel
 
     @Environment(\.callLayout) private var layout: CallLayout
 

--- a/DailyStarterKit/Call/CallControlsView.swift
+++ b/DailyStarterKit/Call/CallControlsView.swift
@@ -2,74 +2,73 @@ import AVFoundation
 import DailyKit
 import SwiftUI
 
-struct CallControlsView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class CallControlsModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: CallManageable
+    private let manager: CallManageable
 
-        init(manager: CallManageable) {
-            self.manager = manager
-            self.camera = manager.camera
-            self.microphone = manager.microphone
+    init(manager: CallManageable) {
+        self.manager = manager
+        self.camera = manager.camera
+        self.microphone = manager.microphone
 
-            manager.publisher(for: .camera)
-                .assign(to: &$camera)
+        manager.publisher(for: .camera)
+            .assign(to: &$camera)
 
-            manager.publisher(for: .microphone)
-                .assign(to: &$microphone)
-        }
-
-        // MARK: - Properties
-
-        @Published private(set) var camera: CallCamera
-        @Published private(set) var microphone: CallMicrophone
-
-        // MARK: - Actions
-
-        func cameraButtonTapped() {
-            guard isAuthorized(for: .video) else {
-                openSettings()
-                return
-            }
-
-            manager.toggleCamera(camera)
-        }
-
-        // Whether the specified media type is either authorized or not yet determined.
-        private func isAuthorized(for mediaType: AVMediaType) -> Bool {
-            [.notDetermined, .authorized].contains(AVCaptureDevice.authorizationStatus(for: mediaType))
-        }
-
-        // Open `Settings.app` to the settings screen for this app that contains the camera and microphone
-        // authorization toggles.
-        private func openSettings() {
-            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-
-            UIApplication.shared.open(url)
-        }
-
-        func microphoneButtonTapped() {
-            guard isAuthorized(for: .audio) else {
-                openSettings()
-                return
-            }
-
-            manager.toggleMicrophone(microphone)
-        }
-
-        func leaveButtonTapped() {
-            manager.leave()
-        }
+        manager.publisher(for: .microphone)
+            .assign(to: &$microphone)
     }
 
-    // MARK: - View
+    // MARK: - Properties
 
-    @EnvironmentObject private var model: Model
-    let shouldShowLeaveButton: Bool
+    @Published private(set) var camera: CallCamera
+    @Published private(set) var microphone: CallMicrophone
+
+    // MARK: - Actions
+
+    func cameraButtonTapped() {
+        guard isAuthorized(for: .video) else {
+            openSettings()
+            return
+        }
+
+        manager.toggleCamera(camera)
+    }
+
+    // Whether the specified media type is either authorized or not yet determined.
+    private func isAuthorized(for mediaType: AVMediaType) -> Bool {
+        [.notDetermined, .authorized].contains(AVCaptureDevice.authorizationStatus(for: mediaType))
+    }
+
+    // Open `Settings.app` to the settings screen for this app that contains the camera and microphone
+    // authorization toggles.
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+
+        UIApplication.shared.open(url)
+    }
+
+    func microphoneButtonTapped() {
+        guard isAuthorized(for: .audio) else {
+            openSettings()
+            return
+        }
+
+        manager.toggleMicrophone(microphone)
+    }
+
+    func leaveButtonTapped() {
+        manager.leave()
+    }
+}
+
+// MARK: - View
+
+struct CallControlsView: View {
+    // MARK: -
 
     private struct CallControlButtonStyle: ButtonStyle {
         private enum Constants {
@@ -110,6 +109,11 @@ struct CallControlsView: View {
                 .clipShape(Circle())
         }
     }
+
+    // MARK: -
+
+    @EnvironmentObject private var model: CallControlsModel
+    let shouldShowLeaveButton: Bool
 
     var body: some View {
         HStack {

--- a/DailyStarterKit/Call/CallDetailsView.swift
+++ b/DailyStarterKit/Call/CallDetailsView.swift
@@ -1,56 +1,58 @@
 import DailyKit
 import SwiftUI
 
-struct CallDetailsView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Sort Orders
+@MainActor
+final class CallDetailsModel: ObservableObject {
+    // MARK: - Sort Orders
 
-        // Sort participants by name.
-        private static let remoteParticipantSortOrder: (CallParticipant, CallParticipant) -> Bool = {
-            $0.username.localizedCaseInsensitiveCompare($1.username) == .orderedAscending
-        }
-
-        // MARK: - Initialization
-
-        private let manager: CallManageable
-
-        init(manager: CallManageable) {
-            self.manager = manager
-            self.participantsCount = manager.participants.count
-            self.localParticipant = manager.participants.local
-            self.remoteParticipants = manager.participants.remote.values
-                .sorted(by: Self.remoteParticipantSortOrder)
-
-            manager.publisher(for: .participants)
-                .map(\.count)
-                .assign(to: &$participantsCount)
-
-            manager.publisher(for: .participants)
-                .map(\.local)
-                .assign(to: &$localParticipant)
-
-            manager.publisher(for: .participants)
-                .map { participants in
-                    // Sort the remote participants whenever they are updated. This should have minimal
-                    // overhead because call details are shown infrequently, but we can do this sorting in the
-                    // `CallManager` if performance here becomes important.
-                    participants.remote.values
-                        .sorted(by: Self.remoteParticipantSortOrder)
-                }
-                .assign(to: &$remoteParticipants)
-        }
-
-        // MARK: - Properties
-
-        @Published private(set) var participantsCount: Int
-        @Published private(set) var localParticipant: CallParticipant
-        @Published private(set) var remoteParticipants: [CallParticipant]
+    // Sort participants by name.
+    private static let remoteParticipantSortOrder: (CallParticipant, CallParticipant) -> Bool = {
+        $0.username.localizedCaseInsensitiveCompare($1.username) == .orderedAscending
     }
 
-    // MARK: - ParticipantDetailView
+    // MARK: - Initialization
+
+    private let manager: CallManageable
+
+    init(manager: CallManageable) {
+        self.manager = manager
+        self.participantsCount = manager.participants.count
+        self.localParticipant = manager.participants.local
+        self.remoteParticipants = manager.participants.remote.values
+            .sorted(by: Self.remoteParticipantSortOrder)
+
+        manager.publisher(for: .participants)
+            .map(\.count)
+            .assign(to: &$participantsCount)
+
+        manager.publisher(for: .participants)
+            .map(\.local)
+            .assign(to: &$localParticipant)
+
+        manager.publisher(for: .participants)
+            .map { participants in
+                // Sort the remote participants whenever they are updated. This should have minimal
+                // overhead because call details are shown infrequently, but we can do this sorting in the
+                // `CallManager` if performance here becomes important.
+                participants.remote.values
+                    .sorted(by: Self.remoteParticipantSortOrder)
+            }
+            .assign(to: &$remoteParticipants)
+    }
+
+    // MARK: - Properties
+
+    @Published private(set) var participantsCount: Int
+    @Published private(set) var localParticipant: CallParticipant
+    @Published private(set) var remoteParticipants: [CallParticipant]
+}
+
+// MARK: - View
+
+struct CallDetailsView: View {
+    // MARK: -
 
     private struct ParticipantDetailView: View {
         let participant: CallParticipant
@@ -67,12 +69,12 @@ struct CallDetailsView: View {
         }
     }
 
-    // MARK: - View
+    // MARK: -
 
     /// A binding presenting views can use to dismiss this view.
     @Binding private(set) var isPresented: Bool
 
-    @EnvironmentObject private var model: Model
+    @EnvironmentObject private var model: CallDetailsModel
 
     var body: some View {
         VStack(spacing: 0) {

--- a/DailyStarterKit/Call/InCallView.swift
+++ b/DailyStarterKit/Call/InCallView.swift
@@ -1,42 +1,42 @@
 import DailyKit
 import SwiftUI
 
-struct InCallView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class InCallModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: CallManageable
+    private let manager: CallManageable
 
-        init(manager: CallManageable) {
-            self.manager = manager
+    init(manager: CallManageable) {
+        self.manager = manager
 
-            manager.publisher(for: .participants)
-                .map(\.count)
-                .assign(to: &$participantsCount)
-        }
-
-        // MARK: - Properties
-
-        // The current participants count from `CallParticipants`.
-        @Published private(set) var participantsCount: Int = 0
-
-        // Visibility of the call controls based on user interaction.
-        @Published private(set) var callControlsOpacity: CGFloat = 1
-
-        // MARK: - Actions
-
-        func backgroundTapped() {
-            // Toggle the call controls whenever the background is tapped.
-            callControlsOpacity = callControlsOpacity.isZero ? 1 : 0
-        }
+        manager.publisher(for: .participants)
+            .map(\.count)
+            .assign(to: &$participantsCount)
     }
 
-    // MARK: - View
+    // MARK: - Properties
 
-    @EnvironmentObject private var model: Model
+    // The current participants count from `CallParticipants`.
+    @Published private(set) var participantsCount: Int = 0
+
+    // Visibility of the call controls based on user interaction.
+    @Published private(set) var callControlsOpacity: CGFloat = 1
+
+    // MARK: - Actions
+
+    func backgroundTapped() {
+        // Toggle the call controls whenever the background is tapped.
+        callControlsOpacity = callControlsOpacity.isZero ? 1 : 0
+    }
+}
+
+// MARK: - View
+
+struct InCallView: View {
+    @EnvironmentObject private var model: InCallModel
 
     var body: some View {
         Group {

--- a/DailyStarterKit/Common/ContextView.swift
+++ b/DailyStarterKit/Common/ContextView.swift
@@ -2,15 +2,15 @@ import DailyKit
 import SwiftUI
 
 struct ContextView<Content: View>: View {
-    @StateObject private var callContainerViewModel: CallContainerView.Model
-    @StateObject private var callControlsOverlayViewModel: CallControlsOverlayView.Model
-    @StateObject private var callControlsViewModel: CallControlsView.Model
-    @StateObject private var callDetailsViewModel: CallDetailsView.Model
-    @StateObject private var gridLayoutViewModel: GridLayoutView.Model
-    @StateObject private var inCallViewModel: InCallView.Model
-    @StateObject private var joinLayoutViewModel: JoinLayoutView.Model
-    @StateObject private var toastOverlayViewModel: ToastOverlayView.Model
-    @StateObject private var waitingLayoutViewModel: WaitingLayoutView.Model
+    @StateObject private var callContainerModel: CallContainerModel
+    @StateObject private var callControlsOverlayModel: CallControlsOverlayModel
+    @StateObject private var callControlsModel: CallControlsModel
+    @StateObject private var callDetailsModel: CallDetailsModel
+    @StateObject private var gridLayoutModel: GridLayoutModel
+    @StateObject private var inCallModel: InCallModel
+    @StateObject private var joinLayoutModel: JoinLayoutModel
+    @StateObject private var toastOverlayModel: ToastOverlayModel
+    @StateObject private var waitingLayoutModel: WaitingLayoutModel
 
     private let content: () -> Content
 
@@ -19,32 +19,32 @@ struct ContextView<Content: View>: View {
         toastManager: ToastManager = .live,
         @ViewBuilder content: @escaping () -> Content
     ) {
-        self._callContainerViewModel = StateObject(
-            wrappedValue: CallContainerView.Model(manager: callManager)
+        self._callContainerModel = StateObject(
+            wrappedValue: CallContainerModel(manager: callManager)
         )
-        self._callControlsOverlayViewModel = StateObject(
-            wrappedValue: CallControlsOverlayView.Model(manager: callManager)
+        self._callControlsOverlayModel = StateObject(
+            wrappedValue: CallControlsOverlayModel(manager: callManager)
         )
-        self._callControlsViewModel = StateObject(
-            wrappedValue: CallControlsView.Model(manager: callManager)
+        self._callControlsModel = StateObject(
+            wrappedValue: CallControlsModel(manager: callManager)
         )
-        self._callDetailsViewModel = StateObject(
-            wrappedValue: CallDetailsView.Model(manager: callManager)
+        self._callDetailsModel = StateObject(
+            wrappedValue: CallDetailsModel(manager: callManager)
         )
-        self._gridLayoutViewModel = StateObject(
-            wrappedValue: GridLayoutView.Model(manager: callManager)
+        self._gridLayoutModel = StateObject(
+            wrappedValue: GridLayoutModel(manager: callManager)
         )
-        self._inCallViewModel = StateObject(
-            wrappedValue: InCallView.Model(manager: callManager)
+        self._inCallModel = StateObject(
+            wrappedValue: InCallModel(manager: callManager)
         )
-        self._joinLayoutViewModel = StateObject(
-            wrappedValue: JoinLayoutView.Model(manager: callManager)
+        self._joinLayoutModel = StateObject(
+            wrappedValue: JoinLayoutModel(manager: callManager)
         )
-        self._toastOverlayViewModel = StateObject(
-            wrappedValue: ToastOverlayView.Model(manager: toastManager)
+        self._toastOverlayModel = StateObject(
+            wrappedValue: ToastOverlayModel(manager: toastManager)
         )
-        self._waitingLayoutViewModel = StateObject(
-            wrappedValue: WaitingLayoutView.Model(callManager: callManager, toastManager: toastManager)
+        self._waitingLayoutModel = StateObject(
+            wrappedValue: WaitingLayoutModel(callManager: callManager, toastManager: toastManager)
         )
 
         self.content = content
@@ -52,14 +52,14 @@ struct ContextView<Content: View>: View {
 
     var body: some View {
         content()
-            .environmentObject(callContainerViewModel)
-            .environmentObject(callControlsOverlayViewModel)
-            .environmentObject(callControlsViewModel)
-            .environmentObject(callDetailsViewModel)
-            .environmentObject(gridLayoutViewModel)
-            .environmentObject(inCallViewModel)
-            .environmentObject(joinLayoutViewModel)
-            .environmentObject(toastOverlayViewModel)
-            .environmentObject(waitingLayoutViewModel)
+            .environmentObject(callContainerModel)
+            .environmentObject(callControlsOverlayModel)
+            .environmentObject(callControlsModel)
+            .environmentObject(callDetailsModel)
+            .environmentObject(gridLayoutModel)
+            .environmentObject(inCallModel)
+            .environmentObject(joinLayoutModel)
+            .environmentObject(toastOverlayModel)
+            .environmentObject(waitingLayoutModel)
     }
 }

--- a/DailyStarterKit/Layouts/GridLayoutView.swift
+++ b/DailyStarterKit/Layouts/GridLayoutView.swift
@@ -2,56 +2,56 @@ import Combine
 import DailyKit
 import SwiftUI
 
-struct GridLayoutView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class GridLayoutModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: CallManageable
-        private var subscriptions: Set<AnyCancellable> = []
+    private let manager: CallManageable
+    private var subscriptions: Set<AnyCancellable> = []
 
-        init(manager: CallManageable) {
-            self.manager = manager
-            self.participants = manager.participants
-            self.localParticipant = manager.participants.local
-            self.visibleParticipants = manager.participants.visible
+    init(manager: CallManageable) {
+        self.manager = manager
+        self.participants = manager.participants
+        self.localParticipant = manager.participants.local
+        self.visibleParticipants = manager.participants.visible
 
-            manager.publisher(for: .participants)
-                .sink { [weak self] participants in
-                    guard let self else { return }
+        manager.publisher(for: .participants)
+            .sink { [weak self] participants in
+                guard let self else { return }
 
-                    // We call `stabilize` before setting the new value to preserve the existing position of
-                    // participants that were already visible in the layout.
-                    self.participants = self.participants.stabilize(participants)
-                }
-                .store(in: &subscriptions)
-        }
-
-        // We store the call participants here, so we can call `stabilize` on the old value when it changes.
-        private var participants: CallParticipants {
-            didSet {
-                self.localParticipant = participants.local
-                self.visibleParticipants = participants.visible
+                // We call `stabilize` before setting the new value to preserve the existing position of
+                // participants that were already visible in the layout.
+                self.participants = self.participants.stabilize(participants)
             }
-        }
+            .store(in: &subscriptions)
+    }
 
-        // MARK: - Properties
-
-        @Published private(set) var localParticipant: CallParticipant
-        @Published private(set) var visibleParticipants: [Int: CallParticipant]
-
-        // MARK: - Actions
-
-        func gridSize(for layout: CallLayout) -> GridGeometry {
-            GridGeometry(layout: layout, participantsCount: visibleParticipants.count)
+    // We store the call participants here, so we can call `stabilize` on the old value when it changes.
+    private var participants: CallParticipants {
+        didSet {
+            self.localParticipant = participants.local
+            self.visibleParticipants = participants.visible
         }
     }
 
-    // MARK: - View
+    // MARK: - Properties
 
-    @EnvironmentObject private var model: Model
+    @Published private(set) var localParticipant: CallParticipant
+    @Published private(set) var visibleParticipants: [Int: CallParticipant]
+
+    // MARK: - Actions
+
+    func gridSize(for layout: CallLayout) -> GridGeometry {
+        GridGeometry(layout: layout, participantsCount: visibleParticipants.count)
+    }
+}
+
+// MARK: - View
+
+struct GridLayoutView: View {
+    @EnvironmentObject private var model: GridLayoutModel
 
     @Environment(\.callLayout) private var layout: CallLayout
 

--- a/DailyStarterKit/Layouts/JoinLayoutView.swift
+++ b/DailyStarterKit/Layouts/JoinLayoutView.swift
@@ -1,76 +1,76 @@
 import DailyKit
 import SwiftUI
 
-struct JoinLayoutView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class JoinLayoutModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: CallManageable
+    private let manager: CallManageable
 
-        init(manager: CallManageable) {
-            self.manager = manager
-            self.localParticipant = manager.participants.local
+    init(manager: CallManageable) {
+        self.manager = manager
+        self.localParticipant = manager.participants.local
 
-            // Disable the join button in the `joining` and `joined` states.
-            manager.publisher(for: .callState)
-                .map { [.joining, .joined].contains($0) }
-                .assign(to: &$isJoinButtonDisabled)
+        // Disable the join button in the `joining` and `joined` states.
+        manager.publisher(for: .callState)
+            .map { [.joining, .joined].contains($0) }
+            .assign(to: &$isJoinButtonDisabled)
 
-            manager.publisher(for: .participants)
-                .map(\.local)
-                .assign(to: &$localParticipant)
-        }
+        manager.publisher(for: .participants)
+            .map(\.local)
+            .assign(to: &$localParticipant)
+    }
 
-        // MARK: - Properties
+    // MARK: - Properties
 
-        @AppStorage("meetingURL") var meetingURLString: String = "" {
-            didSet {
-                // Remove the red error border once the user starts typing again.
-                isMeetingURLValid = true
-            }
-        }
-
-        @AppStorage("username") var username: String = ""
-        @Published private(set) var localParticipant: CallParticipant
-        @Published private(set) var isJoinButtonDisabled: Bool = false
-        @Published private(set) var isMeetingURLValid: Bool = true
-
-        // MARK: - Actions
-
-        func joinButtonTapped() {
-            guard let meetingURL = validateMeetingURL() else {
-                // Show the red error border if the URL was invalid.
-                isMeetingURLValid = false
-                return
-            }
-
-            manager.setUsername(username)
-            manager.join(url: meetingURL)
-
-            // Disable the join button immediately to prevent redundant taps.
-            isJoinButtonDisabled = true
-        }
-
-        // Validate the URL String in `meetingURLString` after prepending `https` if needed. A URL is
-        // considered valid if it is a subdomain of `daily.co` and has at least one character in the path
-        // after the root `/`.
-        private func validateMeetingURL() -> URL? {
-            let urlString = meetingURLString.hasPrefix("https://") ? meetingURLString : "https://\(meetingURLString)"
-            guard let components = URLComponents(string: urlString),
-                  components.host?.hasSuffix(".daily.co") == true,
-                  components.path.count >= 2
-            else { return nil }
-
-            return components.url
+    @AppStorage("meetingURL") var meetingURLString: String = "" {
+        didSet {
+            // Remove the red error border once the user starts typing again.
+            isMeetingURLValid = true
         }
     }
 
-    // MARK: - View
+    @AppStorage("username") var username: String = ""
+    @Published private(set) var localParticipant: CallParticipant
+    @Published private(set) var isJoinButtonDisabled: Bool = false
+    @Published private(set) var isMeetingURLValid: Bool = true
 
-    @EnvironmentObject private var model: Model
+    // MARK: - Actions
+
+    func joinButtonTapped() {
+        guard let meetingURL = validateMeetingURL() else {
+            // Show the red error border if the URL was invalid.
+            isMeetingURLValid = false
+            return
+        }
+
+        manager.setUsername(username)
+        manager.join(url: meetingURL)
+
+        // Disable the join button immediately to prevent redundant taps.
+        isJoinButtonDisabled = true
+    }
+
+    // Validate the URL String in `meetingURLString` after prepending `https` if needed. A URL is
+    // considered valid if it is a subdomain of `daily.co` and has at least one character in the path
+    // after the root `/`.
+    private func validateMeetingURL() -> URL? {
+        let urlString = meetingURLString.hasPrefix("https://") ? meetingURLString : "https://\(meetingURLString)"
+        guard let components = URLComponents(string: urlString),
+              components.host?.hasSuffix(".daily.co") == true,
+              components.path.count >= 2
+        else { return nil }
+
+        return components.url
+    }
+}
+
+// MARK: - View
+
+struct JoinLayoutView: View {
+    @EnvironmentObject private var model: JoinLayoutModel
     @Environment(\.callLayout) private var layout: CallLayout
 
     @FocusState private var inputViewFocusedField: InputViewField?

--- a/DailyStarterKit/Layouts/WaitingLayoutView.swift
+++ b/DailyStarterKit/Layouts/WaitingLayoutView.swift
@@ -3,56 +3,56 @@ import DailyKit
 import SwiftUI
 import UniformTypeIdentifiers
 
-struct WaitingLayoutView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    @MainActor
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+@MainActor
+final class WaitingLayoutModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let callManager: CallManageable
-        private let toastManager: ToastManager
-        private var url: URL? = nil
-        private var subscriptions: Set<AnyCancellable> = []
+    private let callManager: CallManageable
+    private let toastManager: ToastManager
+    private var url: URL? = nil
+    private var subscriptions: Set<AnyCancellable> = []
 
-        init(callManager: CallManageable, toastManager: ToastManager) {
-            self.callManager = callManager
-            self.toastManager = toastManager
-            self.url = callManager.url
-            self.localParticipant = callManager.participants.local
+    init(callManager: CallManageable, toastManager: ToastManager) {
+        self.callManager = callManager
+        self.toastManager = toastManager
+        self.url = callManager.url
+        self.localParticipant = callManager.participants.local
 
-            callManager.publisher(for: .participants)
-                .map(\.local)
-                .assign(to: &$localParticipant)
+        callManager.publisher(for: .participants)
+            .map(\.local)
+            .assign(to: &$localParticipant)
 
-            callManager.publisher(for: .url)
-                .sink { [weak self] url in
-                    guard let self else { return }
+        callManager.publisher(for: .url)
+            .sink { [weak self] url in
+                guard let self else { return }
 
-                    self.url = url
-                }
-                .store(in: &subscriptions)
-        }
-
-        // MARK: - Properties
-
-        @Published private(set) var localParticipant: CallParticipant
-        @Published private(set) var toastOpacity: CGFloat = 0
-
-        // MARK: - Actions
-
-        func copyLinkButtonTapped() {
-            guard let url = self.url else { return }
-
-            UIPasteboard.general.setValue(url, forPasteboardType: UTType.url.identifier)
-
-            toastManager.showToast(Toast(imageName: "link", message: "Link copied to clipboard!"))
-        }
+                self.url = url
+            }
+            .store(in: &subscriptions)
     }
 
-    // MARK: - View
+    // MARK: - Properties
 
-    @EnvironmentObject private var model: Model
+    @Published private(set) var localParticipant: CallParticipant
+    @Published private(set) var toastOpacity: CGFloat = 0
+
+    // MARK: - Actions
+
+    func copyLinkButtonTapped() {
+        guard let url = self.url else { return }
+
+        UIPasteboard.general.setValue(url, forPasteboardType: UTType.url.identifier)
+
+        toastManager.showToast(Toast(imageName: "link", message: "Link copied to clipboard!"))
+    }
+}
+
+// MARK: - View
+
+struct WaitingLayoutView: View {
+    @EnvironmentObject private var model: WaitingLayoutModel
 
     @Environment(\.callLayout) private var layout: CallLayout
 

--- a/DailyStarterKit/Toasts/ToastOverlayView.swift
+++ b/DailyStarterKit/Toasts/ToastOverlayView.swift
@@ -4,29 +4,29 @@ import SwiftUI
 import UniformTypeIdentifiers
 import UIKit
 
-struct ToastOverlayView: View {
-    // MARK: - Model
+// MARK: - Model
 
-    final class Model: ObservableObject {
-        // MARK: - Initialization
+final class ToastOverlayModel: ObservableObject {
+    // MARK: - Initialization
 
-        private let manager: ToastManager
+    private let manager: ToastManager
 
-        init(manager: ToastManager) {
-            self.manager = manager
+    init(manager: ToastManager) {
+        self.manager = manager
 
-            manager.$toast
-                .assign(to: &$toast)
-        }
-
-        // MARK: - Properties
-
-        @Published private(set) var toast: Toast?
+        manager.$toast
+            .assign(to: &$toast)
     }
 
-    // MARK: - View
+    // MARK: - Properties
 
-    @EnvironmentObject private var model: Model
+    @Published private(set) var toast: Toast?
+}
+
+// MARK: - View
+
+struct ToastOverlayView: View {
+    @EnvironmentObject private var model: ToastOverlayModel
 
     // The iOS 17 default animation.
     private let animation = Animation.spring(response: 0.55, dampingFraction: 1, blendDuration: 0)
@@ -95,7 +95,7 @@ struct ToastOverlayView_Previews: PreviewProvider {
                 .previewDisplayName("iPad Landscape")
                 .previewInterfaceOrientation(.landscapeRight)
         }
-        .environmentObject(ToastOverlayView.Model(manager: manager))
+        .environmentObject(ToastOverlayModel(manager: manager))
     }
 }
 #endif


### PR DESCRIPTION
Name models for `SomeView` as `SomeModel`, so it's easier to copy and paste example code.

note: The models are kept in the same file as the view because changing files affects the preview canvas, which would make it harder to work on the related views.