### PR TITLE
Add toggle for Adaptive HEVC

### DIFF
--- a/DailyKit/CallManager/CallManageable.swift
+++ b/DailyKit/CallManager/CallManageable.swift
@@ -37,6 +37,11 @@ public protocol CallManageable {
     /// - Parameter camera: the current `CallCamera` value.
     func toggleCamera(_ camera: CallCamera)
 
+    /// Toggles the video encoding mode between the default and Adaptive HEVC.
+    ///
+    /// - Parameter isAdaptiveHEVCEnabled: whether Adaptive HEVC is enabled.
+    func toggleAdaptiveHEVC(_ isAdaptiveHEVCEnabled: Bool)
+
     /// Toggles the mute state of the microphone.
     ///
     /// - Parameter microphone: the current `CallMicrophone` value.

--- a/DailyKit/CallManager/CallManager.swift
+++ b/DailyKit/CallManager/CallManager.swift
@@ -117,6 +117,27 @@ public final class CallManager: CallManageable {
         }
     }
 
+    public func toggleAdaptiveHEVC(_ isAdaptiveHEVCEnabled: Bool) {
+        assert([.initialized, .left].contains(callState), "Expected to not be in a video call.")
+
+        if isAdaptiveHEVCEnabled {
+            callClient.updatePublishing(.set(
+                camera: .set(
+                    sendSettings: .set(
+                        maxQuality: .set(.high),
+                        encodings: .set(.mode(.iOSOptimized))
+                    )
+                )
+            ))
+        } else {
+            callClient.updatePublishing(.set(
+                camera: .set(
+                    sendSettings: .fromDefaults
+                )
+            ))
+        }
+    }
+
     public func toggleMicrophone(_ microphone: CallMicrophone) {
         switch microphone.audio {
         case .muted:

--- a/DailyKit/CallManager/FakeCallManager.swift
+++ b/DailyKit/CallManager/FakeCallManager.swift
@@ -57,6 +57,10 @@ public final class FakeCallManager: CallManageable {
         }
     }
 
+    public func toggleAdaptiveHEVC(_ isAdaptiveHEVCEnabled: Bool) {
+        // UI state changes before this method is called, so doing nothing here is the happy path.
+    }
+
     public func toggleMicrophone(_ microphone: CallMicrophone) {
         switch microphone.audio {
         case .muted:


### PR DESCRIPTION
Add a toggle to switch between default encoding mode and Adaptive HEVC. Currently this setting needs to be set before joining.

- Extract setup methods in `JoinLayoutView`
- Reduce vertical insets in `inputView`

<img width="413" alt="image" src="https://github.com/daily-demos/daily-ios-starter-kit/assets/349901/6d6c7841-b0bd-4f5c-a636-b27ba3d1de4d">
