### PR TITLE
Include safe area in window size calculation

### DIFF
--- a/DailyStarterKit/Call/CallContainerView.swift
+++ b/DailyStarterKit/Call/CallContainerView.swift
@@ -48,7 +48,7 @@ struct CallContainerView: View {
                 }
             }
             // Set the `callLayout` based on the size of the window.
-            .callLayout(CallLayout(geometry.size))
+            .callLayout(CallLayout(geometry))
             // Prefer the dark color scheme, so text in the status bar will be readable.
             .preferredColorScheme(.dark)
         }

--- a/DailyStarterKit/Call/CallLayout.swift
+++ b/DailyStarterKit/Call/CallLayout.swift
@@ -19,10 +19,14 @@ enum CallLayout {
 }
 
 extension CallLayout {
-    /// Makes a `CallLayout` based on the specified window size.
+    /// Makes a `CallLayout` based on the specified geometry values.
     ///
-    /// - Parameter size: the size of the window.
-    init(_ size: CGSize) {
+    /// - Parameter geometry: the geometry values with which to calculate the window size.
+    init(_ geometry: GeometryProxy) {
+        let size = CGSize(
+            width: geometry.size.width + geometry.safeAreaInsets.leading + geometry.safeAreaInsets.trailing,
+            height: geometry.size.height + geometry.safeAreaInsets.top + geometry.safeAreaInsets.bottom
+        )
         self = size.width < size.height ? .portrait : .landscape
     }
 }


### PR DESCRIPTION
The keyboard affects the safe area, which was causing the calculated window size on iPad in portrait to have landscape dimensions. Including the safe area in the calculation will give us the actual window size.