### PR TITLE
Do not mirror video for environment

### DIFF
--- a/DailyKit/CallManager/CallManager.swift
+++ b/DailyKit/CallManager/CallManager.swift
@@ -203,24 +203,35 @@ extension CallManager: CallClientDelegate {
         _ callClient: CallClient,
         inputsUpdated inputs: InputSettings
     ) {
-        subjects.camera.send(CallCamera(inputs.camera))
-        subjects.microphone.send(CallMicrophone(inputs.microphone))
+        subjects.camera
+            .send(CallCamera(inputs.camera))
+        subjects.microphone
+            .send(CallMicrophone(inputs.microphone))
+
+        participantsBuilder
+            .handleUpdated(CallParticipant(callClient.participants.local, camera: inputs.camera))
+        subjects.participants
+            .send(participantsBuilder.build())
     }
 
     public func callClient(
         _ callClient: CallClient,
         activeSpeakerChanged activeSpeaker: Participant?
     ) {
-        participantsBuilder.activeSpeaker = activeSpeaker?.asCallParticipant
-        subjects.participants.send(participantsBuilder.build())
+        participantsBuilder.activeSpeaker = activeSpeaker
+            .flatMap { CallParticipant($0, camera: callClient.inputs.camera) }
+        subjects.participants
+            .send(participantsBuilder.build())
     }
 
     public func callClient(
         _ callClient: CallClient,
         participantJoined participant: Participant
     ) {
-        participantsBuilder.handleJoined(participant.asCallParticipant)
-        subjects.participants.send(participantsBuilder.build())
+        participantsBuilder
+            .handleJoined(CallParticipant(participant, camera: callClient.inputs.camera))
+        subjects.participants
+            .send(participantsBuilder.build())
     }
 
     public func callClient(
@@ -228,15 +239,19 @@ extension CallManager: CallClientDelegate {
         participantLeft participant: Participant,
         withReason reason: ParticipantLeftReason
     ) {
-        participantsBuilder.handleLeft(participant.asCallParticipant)
-        subjects.participants.send(participantsBuilder.build())
+        participantsBuilder
+            .handleLeft(CallParticipant(participant, camera: callClient.inputs.camera))
+        subjects.participants
+            .send(participantsBuilder.build())
     }
 
     public func callClient(
         _ callClient: CallClient,
         participantUpdated participant: Participant
     ) {
-        participantsBuilder.handleUpdated(participant.asCallParticipant)
-        subjects.participants.send(participantsBuilder.build())
+        participantsBuilder
+            .handleUpdated(CallParticipant(participant, camera: callClient.inputs.camera))
+        subjects.participants
+            .send(participantsBuilder.build())
     }
 }

--- a/DailyKit/CallManager/Models/CallParticipantsBuilder.swift
+++ b/DailyKit/CallManager/Models/CallParticipantsBuilder.swift
@@ -163,6 +163,6 @@ extension CallParticipants.Builder {
     ///
     /// - Parameter callClient: the call client for which to make a builder.
     init(_ callClient: CallClient) {
-        self.init(local: callClient.participants.local.asCallParticipant)
+        self.init(local: CallParticipant(callClient.participants.local, camera: callClient.inputs.camera))
     }
 }

--- a/DailyStarterKit/Common/ParticipantView.swift
+++ b/DailyStarterKit/Common/ParticipantView.swift
@@ -23,11 +23,6 @@ struct ParticipantView: View {
         participant.isLocal ? .fit : .fill
     }
 
-    private var isMirrored: Bool {
-        // Mirror video for the local participant.
-        participant.isLocal
-    }
-
     @Environment(\.callLayout) private var layout: CallLayout
 
     var body: some View {
@@ -42,7 +37,7 @@ struct ParticipantView: View {
             DailyVideoView(
                 track: participant.videoTrack,
                 videoScaleMode: participant.videoScaleMode,
-                isMirrored: isMirrored
+                isMirrored: participant.isVideoMirrored
             )
             .aspectRatio(aspectRatio, contentMode: contentMode)
             .opacity(participant.hasVideo ? 1 : 0)

--- a/DailyStarterKit/Layouts/JoinLayoutView.swift
+++ b/DailyStarterKit/Layouts/JoinLayoutView.swift
@@ -234,7 +234,8 @@ struct JoinLayoutView: View {
 
                 DailyVideoView(
                     track: model.localParticipant.videoTrack,
-                    videoScaleMode: .fit
+                    videoScaleMode: .fit,
+                    isMirrored: model.localParticipant.isVideoMirrored
                 )
 
                 VStack {


### PR DESCRIPTION
Mirroring video for the local participant also mirrored video for the rear facing camera. We will now only mirror local video when the user facing camera is being used.