### PR TITLE
Request authorizations in `CallManager`

### DIFF
--- a/DailyKit/CallManager/CallManageable.swift
+++ b/DailyKit/CallManager/CallManageable.swift
@@ -1,6 +1,7 @@
-import Foundation
+import AVFoundation
 import Combine
 import Daily
+import Foundation
 
 @MainActor
 /// The source of truth for call state and interface to the Daily `CallClient`.
@@ -31,6 +32,14 @@ public protocol CallManageable {
     func publisher<T>(for property: CallClientProperty<T>) -> AnyPublisher<T, Never>
 
     // MARK: - Actions
+
+    /// Determines whether capture of the specified media type is authorized.
+    ///
+    /// The local participant will be prompted for authorization if the status is `notDetermined`.
+    ///
+    /// - Parameter mediaType: the media type for which to check the authorization status.
+    /// - Returns: whether capture of the specified media type is authorized.
+    func isAuthorized(for mediaType: AVMediaType) async -> Bool
 
     /// Toggles the mute state of the camera.
     ///

--- a/DailyKit/CallManager/FakeCallManager.swift
+++ b/DailyKit/CallManager/FakeCallManager.swift
@@ -1,6 +1,7 @@
-import Foundation
+import AVFoundation
 import Combine
 import Daily
+import Foundation
 
 #if DEBUG
 /// A fake implementation of `CallManageable` for previews and testing.
@@ -47,6 +48,8 @@ public final class FakeCallManager: CallManageable {
     }
 
     // MARK: - Actions
+
+    public func isAuthorized(for mediaType: AVMediaType) async -> Bool { true }
 
     public func toggleCamera(_ camera: CallCamera) {
         switch camera.video {

--- a/DailyStarterKit/Call/CallControlsView.swift
+++ b/DailyStarterKit/Call/CallControlsView.swift
@@ -29,18 +29,13 @@ final class CallControlsModel: ObservableObject {
 
     // MARK: - Actions
 
-    func cameraButtonTapped() {
-        guard isAuthorized(for: .video) else {
+    func cameraButtonTapped() async {
+        guard await manager.isAuthorized(for: .video) else {
             openSettings()
             return
         }
 
         manager.toggleCamera(camera)
-    }
-
-    // Whether the specified media type is either authorized or not yet determined.
-    private func isAuthorized(for mediaType: AVMediaType) -> Bool {
-        [.notDetermined, .authorized].contains(AVCaptureDevice.authorizationStatus(for: mediaType))
     }
 
     // Open `Settings.app` to the settings screen for this app that contains the camera and microphone
@@ -51,8 +46,8 @@ final class CallControlsModel: ObservableObject {
         UIApplication.shared.open(url)
     }
 
-    func microphoneButtonTapped() {
-        guard isAuthorized(for: .audio) else {
+    func microphoneButtonTapped() async {
+        guard await manager.isAuthorized(for: .audio) else {
             openSettings()
             return
         }
@@ -118,7 +113,7 @@ struct CallControlsView: View {
     var body: some View {
         HStack {
             Button {
-                model.cameraButtonTapped()
+                Task { await model.cameraButtonTapped() }
             } label: {
                 Image(systemName: model.camera.isMuted ? "video.slash.fill" : "video.fill")
                     .font(.system(size: 24))
@@ -126,7 +121,7 @@ struct CallControlsView: View {
             .buttonStyle(CallControlButtonStyle(isMuted: model.camera.isMuted))
 
             Button {
-                model.microphoneButtonTapped()
+                Task { await model.microphoneButtonTapped() }
             } label: {
                 Image(systemName: model.microphone.isMuted ? "mic.slash.fill" : "mic.fill")
                     .font(.system(size: 26))


### PR DESCRIPTION
Previously we were requesting camera and microphone authorization at a lower level, which did not allow us to control when authorization was requested. We will now request authorization in the `CallManager` and update the inputs after authorization has been requested.

---

Granted | Denied
-|-
<video src="https://github.com/daily-demos/daily-ios-starter-kit/assets/349901/8b21e37a-bcf4-44a8-83c3-3636013c86a1" width="640"> | <video src="https://github.com/daily-demos/daily-ios-starter-kit/assets/349901/276dd776-0ce8-4a57-bb87-efc41d777b80" width="640">
