### PR TITLE
Fix environment mirroring

### DIFF
--- a/DailyStarterKit/Common/DailyVideoView.swift
+++ b/DailyStarterKit/Common/DailyVideoView.swift
@@ -27,17 +27,13 @@ struct DailyVideoView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> VideoView {
         videoView.delegate = context.coordinator
-
-        if isMirrored {
-            videoView.transform = CGAffineTransform(scaleX: -1, y: 1)
-        }
-
         return videoView
     }
 
     func updateUIView(_ videoView: VideoView, context: Context) {
         videoView.track = track
         videoView.videoScaleMode = videoScaleMode
+        videoView.transform = isMirrored ? CGAffineTransform(scaleX: -1, y: 1) : .identity
 
         // Hide the view if we do not have a track.
         videoView.isHidden = track == nil


### PR DESCRIPTION
We were applying the mirroring transform in `makeUIView` instead of `updateUIView`, so it was not being applied when updating the facing mode before the view is created. We currently get a mirrored frame of the original facing mode before it changes, which we will fix in a subsequent change.

Fixes #14.

Before|After
-|-
<image src="https://github.com/daily-demos/daily-ios-starter-kit/assets/349901/0fa7cc7a-9d90-4384-931d-d3f073fd2b40" width="320">|<image src="https://github.com/daily-demos/daily-ios-starter-kit/assets/349901/704bdf6c-83cc-4662-b924-affba79f73da" width="320">

